### PR TITLE
Fix typo in doc page

### DIFF
--- a/doc/acceptpagebreak.htm
+++ b/doc/acceptpagebreak.htm
@@ -15,7 +15,7 @@ mode selected by SetAutoPageBreak().
 <br>
 This method is called automatically and should not be called directly by the application.
 <h2>Example</h2>
-The method is overriden in an inherited class in order to obtain a 3 column layout:
+The method is overridden in an inherited class in order to obtain a 3 column layout:
 <div class="doc-source">
 <pre><code>class PDF extends FPDF
 {


### PR DESCRIPTION

- correct a spelling mistake in `AcceptPageBreak` documentation